### PR TITLE
feat: Update fetchJwt method to support force refresh

### DIFF
--- a/packages/altfire_authenticator/lib/src/authenticator.dart
+++ b/packages/altfire_authenticator/lib/src/authenticator.dart
@@ -34,7 +34,9 @@ class Authenticator {
 
   /// 現ユーザーのJWT(JSON Web Token)を非同期で取得する。
   /// 未サインイン時など、現ユーザーが存在しない場合はnullを返す。
-  Future<String?>? get fetchJwt => _auth.currentUser?.getIdToken();
+  /// forceRefreshが`true`の場合、トークンを強制的に更新する。
+  Future<String?>? fetchJwt({bool forceRefresh = false}) =>
+      _auth.currentUser?.getIdToken(forceRefresh);
 
   /// 匿名サインイン
   Future<UserCredential> signInAnonymously() async {


### PR DESCRIPTION
## 🙌 What I did

- Update fetchJwt method to support force refresh

When using the Firebase Emulator, if it restarts, the Firebase Auth token gets treated as revoked, so to address this issue, I've made forceRefresh public.

<!-- What did you do in this pull request? -->

## ✍️ What I didn't do

<!-- What didn't you address in this pull request? If none, you can write "None". -->

- Translation of doc comments into English

## ✅ Verification

<!-- Build and launch verification + any necessary operational checks -->

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Web

## Screenshots

<!-- If there are UI changes, attach Before and After screenshots or videos -->

## Additional Information

<!-- Any reference information for the reviewer (such as concerns or notes about the implementation) -->
