### PR TITLE
fix: Remove the unpublished getStackTraceElements method

### DIFF
--- a/packages/altfire_tracker/lib/src/tracker.dart
+++ b/packages/altfire_tracker/lib/src/tracker.dart
@@ -108,10 +108,6 @@ class Tracker {
     ]);
   }
 
-  /// Returns a list of StackTraceElements from a StackTrace.
-  List<Map<String, String>> getStackTraceElements(StackTrace stackTrace) =>
-      getStackTraceElements(stackTrace);
-
   /// Set the user ID.
   Future<void> setUserId(String userId) async {
     await Future.wait([


### PR DESCRIPTION
## 🙌 What I did

<!-- What did you do in this pull request? -->

-  Remove the unpublished getStackTraceElements method

## ✍️ What I didn't do

<!-- What didn't you address in this pull request? If none, you can write "None". -->

None

## ✅ Verification

<!-- Build and launch verification + any necessary operational checks -->

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Web

## Screenshots

<!-- If there are UI changes, attach Before and After screenshots or videos -->

## Additional Information

<!-- Any reference information for the reviewer (such as concerns or notes about the implementation) -->
