### PR TITLE
build: Delete unnecessary library names

### DIFF
--- a/packages/altfire_authenticator/lib/altfire_authenticator.dart
+++ b/packages/altfire_authenticator/lib/altfire_authenticator.dart
@@ -1,5 +1,5 @@
 /// altfire_authenticator with FlutterFire Authentication.
-library altfire_authenticator;
+library;
 
 export 'package:firebase_auth/firebase_auth.dart'
     show

--- a/packages/altfire_configurator/lib/altfire_configurator.dart
+++ b/packages/altfire_configurator/lib/altfire_configurator.dart
@@ -1,5 +1,5 @@
 /// altfire_configurator with FlutterFire Remote Config.
-library altfire_configurator;
+library;
 
 export 'src/config.dart';
 export 'src/configurator.dart';

--- a/packages/altfire_messenger/lib/altfire_messenger.dart
+++ b/packages/altfire_messenger/lib/altfire_messenger.dart
@@ -1,6 +1,6 @@
 /// altfire_messenger with FlutterFire Messaging, Local Notifications,
 /// In-App Messaging, and Firebase Installation ID.
-library altfire_messenger;
+library;
 
 export 'package:firebase_messaging/firebase_messaging.dart'
     show AuthorizationStatus;

--- a/packages/altfire_tracker/lib/altfire_tracker.dart
+++ b/packages/altfire_tracker/lib/altfire_tracker.dart
@@ -1,5 +1,5 @@
 /// altfire_tracker with FlutterFire Analytics and Crashlytics.
-library altfire_tracker;
+library;
 
 export 'package:firebase_crashlytics_platform_interface/firebase_crashlytics_platform_interface.dart'
     show MethodChannelFirebaseCrashlytics;


### PR DESCRIPTION
## 🔗 Issue Link

None.

## 🙌 What I did

<!-- What did you do in this pull request? -->

- Deleted unnecessary library names in response to the unnecessary_library_name warning from Dart 3.4.0.

![CleanShot 2024-05-28 at 08 43 30](https://github.com/altive/altfire/assets/45661924/17fd3aa4-1732-46ff-b70a-303233067670)

## ✍️ What I didn't do

<!-- What didn't you address in this pull request? If none, you can write "None". -->

None

## ✅ Verification

<!-- Build and launch verification + any necessary operational checks -->

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Web

## Screenshots

<!-- If there are UI changes, attach Before and After screenshots or videos -->

## Additional Information

<!-- Any reference information for the reviewer (such as concerns or notes about the implementation) -->
