### PR TITLE
fix: Modify dependabot directories to use wildcards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,18 +10,8 @@ updates:
     directories:
       - "/"
       - "/example"
-      - "/packages/altfire_authenticator"
-      - "/packages/altfire_authenticator/example"
-      - "/packages/altfire_configurator"
-      - "/packages/altfire_configurator/example"
-      - "/packages/altfire_lints"
-      - "/packages/altfire_lints/example"
-      - "/packages/altfire_lints_test"
-      - "/packages/altfire_lints_test/example"
-      - "/packages/altfire_messenger"
-      - "/packages/altfire_messenger/example"
-      - "/packages/altfire_tracker"
-      - "/packages/altfire_tracker/example"
+      - "/packages/*"
+      - "/packages/*/example"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
## 🔗 Issue Link

None.

## 🙌 What I did

<!-- What did you do in this pull request? -->

- Modify dependabot directories to use wildcards

## ✍️ What I didn't do

<!-- What didn't you address in this pull request? If none, you can write "None". -->

## ✅ Verification

<!-- Build and launch verification + any necessary operational checks -->

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Web

## Screenshots

<!-- If there are UI changes, attach Before and After screenshots or videos -->

## Additional Information

<!-- Any reference information for the reviewer (such as concerns or notes about the implementation) -->

https://github.com/altive/altfire/network/updates/20426902/jobs

There was an error with dependabot not finding `/packages/altfire_lints/example`! It should work with this fix.