### PR TITLE
feat(tracker): Add one navigator observer

### DIFF
--- a/packages/altfire_tracker/lib/src/tracker.dart
+++ b/packages/altfire_tracker/lib/src/tracker.dart
@@ -136,16 +136,27 @@ class Tracker {
     }
   }
 
-  /// Returns a list of NavigatorObservers to register with Navigator.
+  /// Returns a FirebaseAnalyticsObserver as NavigatorObserver.
+  /// Use [nameExtractor] to set the parameter value to send.
+  NavigatorObserver navigatorObserver({
+    String? Function(RouteSettings) nameExtractor = defaultNameExtractor,
+    bool Function(Route<dynamic>?) routeFilter = defaultRouteFilter,
+  }) {
+    return FirebaseAnalyticsObserver(
+      analytics: _analytics,
+      nameExtractor: nameExtractor,
+      routeFilter: routeFilter,
+    );
+  }
+
+  /// Returns a list of NavigatorObservers with FirebaseAnalyticsObserver.
   /// Use [nameExtractor] to set the parameter value to send.
   List<NavigatorObserver> navigatorObservers({
     String? Function(RouteSettings) nameExtractor = defaultNameExtractor,
     bool Function(Route<dynamic>?) routeFilter = defaultRouteFilter,
   }) {
     return [
-      // Returns a NavigatorObserver of FirebaseAnalytics.
-      FirebaseAnalyticsObserver(
-        analytics: _analytics,
+      navigatorObserver(
         nameExtractor: nameExtractor,
         routeFilter: routeFilter,
       ),

--- a/packages/altfire_tracker/test/src/tracker_test.dart
+++ b/packages/altfire_tracker/test/src/tracker_test.dart
@@ -244,6 +244,26 @@ void main() {
       verifyNoMoreInteractions(analytics);
     });
 
+    test('navigatorObserver should return a FirebaseAnalyticsObserver',
+        () async {
+      final crashlytics = MockFirebaseCrashlytics();
+      final analytics = MockFirebaseAnalytics();
+      final tracker = Tracker(
+        crashlytics: crashlytics,
+        analytics: analytics,
+      );
+
+      String nameExtractor(RouteSettings settings) => settings.name!;
+      bool routerFilter(Route<dynamic>? route) => route != null;
+      final got = tracker.navigatorObserver(
+        nameExtractor: nameExtractor,
+        routeFilter: routerFilter,
+      );
+
+      expect(got, isA<NavigatorObserver>());
+      expect(got, isA<FirebaseAnalyticsObserver>());
+    });
+
     test('navigatorObservers should return a list of NavigatorObservers',
         () async {
       final crashlytics = MockFirebaseCrashlytics();
@@ -261,8 +281,10 @@ void main() {
       );
 
       expect(got, isA<List<NavigatorObserver>>());
-      expect(got.length, 1);
-      expect(got[0], isA<FirebaseAnalyticsObserver>());
+      expect(
+        got.whereType<FirebaseAnalyticsObserver>(),
+        hasLength(1),
+      );
     });
 
     test('trackScreenView should call setCurrentScreen on analytics', () async {


### PR DESCRIPTION
## 🔗 Issue Link

none.

## 🙌 What I did

<!-- What did you do in this pull request? -->

- Added because sometimes you only want to use one FirebaseAnalyticsObserver instead of a list of NavigatorObservers!

## ✍️ What I didn't do

<!-- What didn't you address in this pull request? If none, you can write "None". -->

## ✅ Verification

<!-- Build and launch verification + any necessary operational checks -->

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Web

## Screenshots

<!-- If there are UI changes, attach Before and After screenshots or videos -->

## Additional Information

<!-- Any reference information for the reviewer (such as concerns or notes about the implementation) -->
